### PR TITLE
Add basic `LazyVim` structure

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,1 @@
+require("config.lazy")

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -1,0 +1,35 @@
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Make sure to setup `mapleader` and `maplocalleader` before
+-- loading lazy.nvim so that mappings are correct.
+-- This is also a good place to setup other settings (vim.opt)
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- Setup lazy.nvim
+require("lazy").setup({
+  spec = {
+    -- import your plugins
+    { import = "plugins" },
+  },
+  -- Configure any other settings here. See the documentation for more details.
+  -- colorscheme that will be used when installing plugins.
+  install = { colorscheme = { "habamax" } },
+  -- automatically check for plugin updates
+  checker = { enabled = true },
+})

--- a/lua/plugins/vim-fugitive.lua
+++ b/lua/plugins/vim-fugitive.lua
@@ -1,0 +1,3 @@
+return {
+  "tpope/vim-fugitive"
+}


### PR DESCRIPTION
## Summary

This PR sets up the initial structure for `LazyVim` and includes `vim-fugitive` as an example of how to add a plugin. It introduces:

- The base configuration for `LazyVim`.
- An example plugin (vim-fugitive) to demonstrate the process of adding plugins.