### PR TITLE
Add `vim-options` file

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -13,13 +13,10 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
     os.exit(1)
   end
 end
+
 vim.opt.rtp:prepend(lazypath)
 
--- Make sure to setup `mapleader` and `maplocalleader` before
--- loading lazy.nvim so that mappings are correct.
--- This is also a good place to setup other settings (vim.opt)
-vim.g.mapleader = " "
-vim.g.maplocalleader = "\\"
+require("config/vim-options")
 
 -- Setup lazy.nvim
 require("lazy").setup({

--- a/lua/config/vim-options.lua
+++ b/lua/config/vim-options.lua
@@ -1,0 +1,5 @@
+-- Make sure to setup `mapleader` and `maplocalleader` before
+-- loading lazy.nvim so that mappings are correct.
+-- This is also a good place to setup other settings (vim.opt)
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"

--- a/lua/config/vim-options.lua
+++ b/lua/config/vim-options.lua
@@ -1,5 +1,12 @@
--- Make sure to setup `mapleader` and `maplocalleader` before
--- loading lazy.nvim so that mappings are correct.
--- This is also a good place to setup other settings (vim.opt)
 vim.g.mapleader = " "
 vim.g.maplocalleader = "\\"
+
+vim.opt.clipboard = "unnamedplus"     -- Use system clipboard
+vim.opt.expandtab = true              -- Use spaces instead of tabs
+vim.opt.softtabstop = 2               -- Number of spaces when hitting <Tab> in insert mode
+vim.opt.shiftwidth = 2                -- Number of spaces for indentation
+vim.opt.swapfile = false
+vim.opt.tabstop = 2                   -- Number of spaces a tab counts for
+vim.opt.undofile = true               -- Enable persistent undo
+
+vim.wo.number = true

--- a/lua/config/vim-options.lua
+++ b/lua/config/vim-options.lua
@@ -3,6 +3,7 @@ vim.g.maplocalleader = "\\"
 
 vim.opt.clipboard = "unnamedplus"     -- Use system clipboard
 vim.opt.expandtab = true              -- Use spaces instead of tabs
+vim.opt.path:append("**")
 vim.opt.softtabstop = 2               -- Number of spaces when hitting <Tab> in insert mode
 vim.opt.shiftwidth = 2                -- Number of spaces for indentation
 vim.opt.swapfile = false


### PR DESCRIPTION
## Summary

Following @Nicolasvb23's work in #2, this PR adds a `vim-options` file to define basic `Vim` configurations