### PR TITLE
Add `syntax highlight` and `folding`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,1 +1,3 @@
 require("config.lazy")
+
+vim.cmd.colorscheme "catppuccin"

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,5 +1,7 @@
 {
+  "catppuccin": { "branch": "main", "commit": "5b5e3aef9ad7af84f463d17b5479f06b87d5c429" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
+  "nvim-treesitter": { "branch": "master", "commit": "5f38dffb6a07669a678f073bfe0f62b1a020dffc" },
   "vim-bundler": { "branch": "master", "commit": "c261509e78fc8dc55ad1fcf3cd7cdde49f35435c" },
   "vim-endwise": { "branch": "master", "commit": "f6a32fbe4d4e511d446ac189e926f8e24f69cc1e" },
   "vim-fugitive": { "branch": "master", "commit": "4a745ea72fa93bb15dd077109afbb3d1809383f2" },

--- a/lua/config/vim-options.lua
+++ b/lua/config/vim-options.lua
@@ -3,6 +3,9 @@ vim.g.maplocalleader = "\\"
 
 vim.opt.clipboard = "unnamedplus"     -- Use system clipboard
 vim.opt.expandtab = true              -- Use spaces instead of tabs
+vim.opt.foldmethod = "expr"
+vim.opt.foldexpr = "nvim_treesitter#foldexpr()"
+vim.opt.foldenable = false            -- Start with folds open
 vim.opt.path:append("**")
 vim.opt.softtabstop = 2               -- Number of spaces when hitting <Tab> in insert mode
 vim.opt.shiftwidth = 2                -- Number of spaces for indentation

--- a/lua/plugins/catppuccin.lua
+++ b/lua/plugins/catppuccin.lua
@@ -1,0 +1,5 @@
+return {
+  "catppuccin/nvim",
+  name = "catppuccin",
+  priority = 1000
+}

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -6,6 +6,10 @@ return {
 
     config.setup({
       auto_install = true,
+      highlight = {
+        enable = true,
+        additional_vim_regex_highlighting = false
+      },
     })
   end
 }

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,0 +1,11 @@
+return {
+  "nvim-treesitter/nvim-treesitter",
+  build = ":TSUpdate",
+  config = function()
+    local config = require("nvim-treesitter.configs")
+
+    config.setup({
+      auto_install = true,
+    })
+  end
+}


### PR DESCRIPTION
## Summary
This PR introduces the `treesitter` and `catppuccin` plugins to enhance syntax highlighting and folding.

- `treesitter` is used for both syntax highlighting and code folding.

- `catppuccin` has been added to provide a color scheme, using its integration with `treesitter`.

We encountered some issues with `treesitter`'s indentation feature, so we have opted to keep it disabled for now.

### Before
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/ea6dc642-c00f-4328-97fe-1704020f2c81" />

### After
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/badcb41a-4162-4d4c-ad1e-522cb3325aba" />
