### PR TITLE
Add `vim-trailing-whitespace`

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -5,5 +5,6 @@
   "vim-fugitive": { "branch": "master", "commit": "4a745ea72fa93bb15dd077109afbb3d1809383f2" },
   "vim-gitgutter": { "branch": "main", "commit": "6620e5fbbe6a28de0bfed081f5bd2767023b7eea" },
   "vim-rails": { "branch": "master", "commit": "b0a5c76f86ea214ade36ab0b811e730c3f0add67" },
-  "vim-rhubarb": { "branch": "master", "commit": "386daa2e9d98e23e27ad089afcbe5c5a903e488d" }
+  "vim-rhubarb": { "branch": "master", "commit": "386daa2e9d98e23e27ad089afcbe5c5a903e488d" },
+  "vim-trailing-whitespace": { "branch": "master", "commit": "5540b3faa2288b226a8d9a4e8244558b12c598aa" }
 }

--- a/lua/plugins/plugins.lua
+++ b/lua/plugins/plugins.lua
@@ -2,5 +2,6 @@ return {
   "airblade/vim-gitgutter",
   "tpope/vim-bundler",
   "tpope/vim-endwise",
-  "tpope/vim-rails"
+  "tpope/vim-rails",
+  "bronson/vim-trailing-whitespace"
 }


### PR DESCRIPTION
Added the plugin `vim-trailing-whitespace` to highlight with red the whitespaces at the end of lines.
<img width="904" alt="image" src="https://github.com/user-attachments/assets/a8dcd91d-284c-4ab1-bde2-d77d1d7c069a" />

Issue #14 