### PR TITLE
Fix working directory change when opening files from different directories

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -1,0 +1,13 @@
+local autocmd = vim.api.nvim_create_autocmd
+
+-- Change the working directory only if the file is not in a subdirectory of the current one
+autocmd("BufWinEnter", {
+  pattern = "*",
+  callback = function()
+    local file_dir = vim.fn.expand('%:p:h')
+    local cwd = vim.fn.getcwd()
+    if not string.match(file_dir, "^" .. cwd) then
+      vim.cmd('silent! lcd ' .. file_dir)
+    end
+  end,
+})

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -20,6 +20,7 @@ vim.opt.rtp:prepend(lazypath)
 
 require("config/vim-options")
 require("config/keymaps")
+require("config/autocmds")
 
 local user_custom_file = vim.fn.expand("~/.config/nvim/lua/config/user-customizations.lua")
 


### PR DESCRIPTION
### Summary
This PR fixes the working directory behavior when opening a file from a different directory, such as:
- Using LSP's go-to-definition feature.
- Opening a gem with `gem open`.
- Using `nvim --path` to open a directory/file.
