### PR TITLE
Fix `Gemfile.lock` syntax highlight

### DIFF
--- a/lua/plugins/plugins.lua
+++ b/lua/plugins/plugins.lua
@@ -2,7 +2,6 @@ return {
   "airblade/vim-gitgutter",
   "bronson/vim-trailing-whitespace",
   "github/copilot.vim",
-  "tpope/vim-bundler",
   "tpope/vim-endwise",
   "tpope/vim-rails",
   "tpope/vim-repeat",

--- a/lua/plugins/vim-bundler.lua
+++ b/lua/plugins/vim-bundler.lua
@@ -1,0 +1,4 @@
+return {
+  "tpope/vim-bundler",
+  event = "VeryLazy"
+}


### PR DESCRIPTION
## Why?
The `vim-bundler` plugin provides syntax highlighting for `Gemfile.lock`, as confirmed in [this section of the plugin](https://github.com/tpope/vim-bundler/blob/c261509e78fc8dc55ad1fcf3cd7cdde49f35435c/plugin/bundler.vim#L113-L146).

However, currently, there is no syntax highlighting applied when opening `Gemfile.lock`:

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/69f3e3d2-2dfc-4447-b3c7-b65ffa8fdc85" />

## What is happening?
The `vim-bundler` plugin applies syntax highlighting using [Vim autocommands](https://github.com/tpope/vim-bundler/blob/c261509e78fc8dc55ad1fcf3cd7cdde49f35435c/plugin/bundler.vim#L167-L178), which are executed when opening a file.

At first, I suspected that the syntax highlight rules defined in `vim-bundler` might not be working. However, copying them into a separate syntax file and applying them manually confirmed that they do work as expected.

## Root Cause
Using `:scriptnames`, which lists the scripts loaded when opening `Gemfile.lock`, I found that `vim-bundler` is loaded eagerly, meaning other scripts executed after it might be overriding its syntax rules. The logs can be found [here](https://github.com/user-attachments/files/19528515/master.txt).

A key suspect is the [syntax/synload.vim](https://github.com/neovim/neovim/blob/ee143aaf65a0e662c42c636aa4a959682858b3e7/runtime/syntax/synload.vim#L25-L57) script, which removes previously declared syntax definitions, potentially wiping out the rules set by vim-bundler.

## How does this PR fix it?
This PR lazy loads `vim-bundler`, ensuring that it runs after the conflicting `synload.vim` script. 

Closes #17 

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/55f0ed3c-1eee-48d3-b445-0f421c756f1e" />
