### PR TITLE
Add `vim-javascript` plugin

### DIFF
--- a/lua/plugins/plugins.lua
+++ b/lua/plugins/plugins.lua
@@ -2,6 +2,7 @@ return {
   "airblade/vim-gitgutter",
   "bronson/vim-trailing-whitespace",
   "github/copilot.vim",
+  "pangloss/vim-javascript",
   "tpope/vim-bundler",
   "tpope/vim-endwise",
   "tpope/vim-rails",


### PR DESCRIPTION
## Summary

This plugin provides:
- Better syntax highlight for `javascript`.
- Improves `javascript` indentation. 
- Support for `javascript` folding.

Closes #34 

### Before
![image](https://github.com/user-attachments/assets/e1e5ca78-f8cd-450d-b959-85238714b195)

### After

![image](https://github.com/user-attachments/assets/56ab2e05-6c01-4f8a-93d7-3bb279832b6f)