### PR TITLE
Use `ripgrep` as the search engine in files picker

### DIFF
--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -5,7 +5,7 @@ vim.keymap.set("n", "gr", vim.lsp.buf.references, {})
 -- Snacks keymaps
 local opts = { hidden = true }
 
-vim.keymap.set("n", "<C-b>", function() Snacks.picker.buffers(opts) end)
+vim.keymap.set("n", "<C-b>", function() Snacks.picker.buffers({ hidden = true, cmd = "rg" }) end)
 vim.keymap.set("n", "<C-/>", function() Snacks.picker.grep(opts) end)
 vim.keymap.set("n", "<C-n>", function() Snacks.explorer(opts) end)
-vim.keymap.set("n", "<C-p>", function() Snacks.picker.files(opts) end)
+vim.keymap.set("n", "<C-p>", function() Snacks.picker.files({ hidden = true, cmd = "rg" }) end)


### PR DESCRIPTION
The default search engine is `fd` but it doesn't seems to be working properly...at least for our use cases, for example:

```sh
$ fd application.rb
config/application.rb
```

But by running:

```sh
$ fd config/
```

We don't get anything 🙁 

See `Snacks.nvim` docs about the files picker:
https://github.com/folke/snacks.nvim/blob/bc0630e43be5699bb94dadc302c0d21615421d93/docs/picker.md?plain=1#L1042