### PR TITLE
Fix cwd autocommand

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -1,13 +1,31 @@
 local autocmd = vim.api.nvim_create_autocmd
 
--- Change the working directory only if the file is not in a subdirectory of the current one
-autocmd("BufWinEnter", {
+local root_names = { '.git', 'LICENSE', 'LICENSE.txt', 'MIT-LICENSE' }
+
+local root_cache = {}
+
+local function find_root(path)
+  local root_file = vim.fs.find(root_names, { path = path, upward = true })[1]
+  if not root_file then return nil end
+
+  local root = vim.fs.dirname(root_file)
+  root_cache[path] = root
+
+  return root
+end
+
+autocmd({ "BufWinEnter", "BufWinLeave" }, {
   pattern = "*",
   callback = function()
-    local file_dir = vim.fn.expand('%:p:h')
-    local cwd = vim.fn.getcwd()
-    if not string.match(file_dir, "^" .. cwd) then
-      vim.cmd('silent! lcd ' .. file_dir)
+    -- Skip snacks windows
+    if vim.bo.filetype:match("^snacks") then return end
+
+    local path = vim.fn.expand('%:p:h')
+
+    local root = root_cache[path] or find_root(path)
+
+    if root then
+      vim.cmd('silent! cd ' .. root)
     end
   end,
 })


### PR DESCRIPTION
## Summary
Fixed autocommand to ensure the cwd is correctly set to the root of the project or gem.

Introduced caching mechanisms to enhance performance during project navigation.

Refactored setup based on guidance from [this Reddit post](https://www.reddit.com/r/neovim/comments/zy5s0l/you_dont_need_vimrooter_usually_or_how_to_set_up).

## How was it tested?
- Navigating between a gem and a `Rails` app using `Ctrl + i` and `Ctrl + o`, ensuring the cwd is set correctly in both directions.

- Opening a subdirectory of a `Rails` app directly via terminal or with `:e` in nvim and confirming proper cwd handling.

- Using the "go to definition" `LSP` keymap to enter a gem and verifying that the root directory is set correctly in the gem.