### PR TITLE
Add color highlighter

### DIFF
--- a/lua/plugins/nvim-colorizer.lua
+++ b/lua/plugins/nvim-colorizer.lua
@@ -1,0 +1,9 @@
+return {
+  "catgoose/nvim-colorizer.lua",
+  opts = {
+    user_default_options = {
+      mode = "foreground",
+      tailwind = true,
+    },
+  }
+}


### PR DESCRIPTION
This PR adds [nvim-colorizer](https://github.com/norcalli/nvim-colorizer.lua) plugin which adds syntax highlighting for colors 🙂 (works with tailwind)

There are two modes, background (that highlights the background of the word), and foreground (that highlights the word).

#### Foreground
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/d9f08938-7c67-4e8d-8891-58ad9c754aa0" />

#### Background
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/e434ec71-b324-43dd-82e1-85df7a01cce3" />

It works with css too, see:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/ccb00516-f3ec-48a9-825c-da4077e825f9" />
