### PR TITLE
Fix `Snacks.picker.grep()` custom `<C-/>` keymap not working in tmux

### DIFF
--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -9,3 +9,4 @@ vim.keymap.set("n", "<C-b>", function() Snacks.picker.buffers({ hidden = true, c
 vim.keymap.set("n", "<C-/>", function() Snacks.picker.grep(opts) end)
 vim.keymap.set("n", "<C-n>", function() Snacks.explorer(opts) end)
 vim.keymap.set("n", "<C-p>", function() Snacks.picker.files({ hidden = true, cmd = "rg" }) end)
+vim.keymap.set("n", "<C-_>", "<C-/>", { remap = true })


### PR DESCRIPTION
This PR fixes our `<C-/>` keymap for `Snacks.picker.grep()` not working in tmux by remapping it to `<C-_>`