### PR TITLE
Add compatible keymaps for picker's history navigation

### DIFF
--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -27,6 +27,8 @@ return {
         input = {
           keys = {
            ["<Esc>"] = { "close", mode = { "n", "i" } },
+           ["<M-Down>"] = { "history_forward", mode = { "i", "n" } },
+           ["<M-Up>"] = { "history_back", mode = { "i", "n" } },
           }
         }
       },


### PR DESCRIPTION
#### Summary

On `MacOS`, using `Ctrl` + arrow keys conflicts with the system’s built-in shortcuts. To prevent this, this PR introduces alternative key mappings in `lua/plugins/snacks.lua`, avoiding the use of `Ctrl`.

Key mapping additions:

* Added `<M-Down>` to navigate forward in history in both insert (`i`) and normal (`n`) modes.
* Added `<M-Up>` to navigate backward in history in both insert (`i`) and normal (`n`) modes.

#### Usage

https://github.com/user-attachments/assets/7036786a-cea7-430d-960c-6b0eafcbb736

---

> [!warning]
> To use `Alt`-based shortcuts in `iTerm2`, make sure the `Option` key is configured properly.
See: [Making the Alt key work in iTerm2](https://www.clairecodes.com/blog/2018-10-15-making-the-alt-key-work-in-iterm2/)