### PR TITLE
Add missing `catppuccin.nvim` integrations

### DIFF
--- a/lua/plugins/catppuccin.lua
+++ b/lua/plugins/catppuccin.lua
@@ -7,6 +7,5 @@ return {
     require("catppuccin").setup({
       transparent_background = true,
     })
-    vim.cmd.colorscheme "catppuccin-mocha"
   end
 }

--- a/lua/plugins/catppuccin.lua
+++ b/lua/plugins/catppuccin.lua
@@ -6,6 +6,11 @@ return {
   config = function()
     require("catppuccin").setup({
       transparent_background = true,
+      integrations = {
+        copilot_vim = true,
+        gitgutter = true,
+        snacks = true,
+      },
     })
   end
 }


### PR DESCRIPTION
These integrations are disabled by default.

See https://github.com/catppuccin/nvim?tab=readme-ov-file#integrations