### PR TITLE
Use rounded borders for floating windows

### DIFF
--- a/lua/config/vim-options.lua
+++ b/lua/config/vim-options.lua
@@ -12,5 +12,6 @@ vim.opt.shiftwidth = 2                -- Number of spaces for indentation
 vim.opt.swapfile = false
 vim.opt.tabstop = 2                   -- Number of spaces a tab counts for
 vim.opt.undofile = true               -- Enable persistent undo
+vim.opt.winborder = 'rounded'         -- Use rounded borders for windows
 
 vim.wo.number = true


### PR DESCRIPTION
#### Why?

It's hard to distinguish between floating windows and the main window.

#### Without border
<img width="1552" height="987" alt="image" src="https://github.com/user-attachments/assets/72c9cedf-97ac-4b2b-9d87-7ab607f4fb0a" />


#### With border
<img width="1552" height="987" alt="image" src="https://github.com/user-attachments/assets/7a7f4488-777e-41ea-99cd-23fb3eec8751" />
