### PR TITLE
Add `git` related keymaps

### DIFF
--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -16,3 +16,8 @@ vim.keymap.set("n", "<leader>cd", vim.diagnostic.open_float)
 vim.keymap.set("n", "<leader>ld", vim.diagnostic.setloclist)
 vim.keymap.set("n", "[d", vim.diagnostic.goto_prev)
 vim.keymap.set("n", "]d", vim.diagnostic.goto_next)
+
+-- Git keymaps
+vim.keymap.set({"n", "v"}, "gl", ":Git blame<CR>")
+vim.keymap.set({"n", "v"}, "gb", ":GBrowse<CR>")
+vim.keymap.set("n", "<C-g>", function() Snacks.picker.git_status({ ignored = false, cmd = "rg" }) end)


### PR DESCRIPTION
#### Why?
I found these keymaps useful.

#### Keymaps
- Keymap for blaming files
- Keymap to browse the file/commit in git (supports visual mode)
- Keymap to show the files with changes (staged or not)