### PR TITLE
Add grep word under cursor keymap

### DIFF
--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -2,13 +2,15 @@
 vim.keymap.set("n", "gd", function() Snacks.picker.lsp_definitions() end)
 vim.keymap.set("n", "gr", function() Snacks.picker.lsp_references() end)
 
--- Snacks keymaps
+-- Files navigation keymaps
 local opts = { hidden = true }
 
 vim.keymap.set("n", "<C-b>", function() Snacks.picker.buffers({ hidden = true, cmd = "rg" }) end)
-vim.keymap.set("n", "<C-/>", function() Snacks.picker.grep(opts) end)
 vim.keymap.set("n", "<C-n>", function() Snacks.explorer(opts) end)
 vim.keymap.set("n", "<C-p>", function() Snacks.picker.files({ hidden = true, cmd = "rg" }) end)
+
+-- Fuzzy finder keymaps
+vim.keymap.set("n", "<C-/>", function() Snacks.picker.grep(opts) end)
 vim.keymap.set("n", "<C-_>", "<C-/>", { remap = true })
 vim.keymap.set({"n", "v"}, "<C-s>", function() Snacks.picker.grep_word(opts) end)
 


### PR DESCRIPTION
#### Why?

To easily search the current word under the cursor (or selected in visual mode).

https://github.com/user-attachments/assets/1ad3599c-6fcc-4ff9-94e3-f3da0fce91c4

