### PR TITLE
Add `nvim-treesitter`

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,0 +1,14 @@
+return {
+  "nvim-treesitter/nvim-treesitter",
+  build = ":TSUpdate",
+  config = function ()
+    local configs = require("nvim-treesitter.configs")
+
+    configs.setup({
+      ensure_installed = { "c", "lua", "vim", "vimdoc", "ruby", "javascript", "html", "embedded_template", "typescript", "tsx" },
+      sync_install = false,
+      highlight = { enable = true },
+      indent = { enable = true },
+    })
+  end
+}


### PR DESCRIPTION
#### Why?

This allows us to have syntax highlighting and indentation in a bunch of different languages (like `typescript` or `tsx`).

Please test that this change doesn't break anything from your set up (we already had problems with `treesitter` in the past, see #21)