### PR TITLE
Fix configuration incompatibility with `Neovim` 0.10 and earlier

### DIFF
--- a/lua/config/vim-options.lua
+++ b/lua/config/vim-options.lua
@@ -12,6 +12,8 @@ vim.opt.shiftwidth = 2                -- Number of spaces for indentation
 vim.opt.swapfile = false
 vim.opt.tabstop = 2                   -- Number of spaces a tab counts for
 vim.opt.undofile = true               -- Enable persistent undo
-vim.opt.winborder = 'rounded'         -- Use rounded borders for windows
+if vim.fn.has("nvim-0.11") == 1 then
+  vim.opt.winborder = 'rounded'         -- Use rounded borders for windows
+end
 
 vim.wo.number = true


### PR DESCRIPTION
#### Summary

The option `winborder` was added in `Neovim 0.11` so this configuration breaks neovim when using an earlier version.

See the PR in which it was added:
https://github.com/neovim/neovim/pull/31074