### PR TITLE
Add borders in completions windows

### DIFF
--- a/lua/plugins/completions.lua
+++ b/lua/plugins/completions.lua
@@ -106,6 +106,12 @@ return {
         end,
       },
       sorting = defaults.sorting,
-    }
+    },
+    cmp.setup({
+      window = {
+        completion = cmp.config.window.bordered(),
+        documentation = cmp.config.window.bordered(),
+      },
+    })
   end,
 }


### PR DESCRIPTION
#### Why?

Sometimes is hard to distinguish between the floating windows and the main window.

#### Before

<img width="1728" height="1079" alt="image" src="https://github.com/user-attachments/assets/d3bd819d-6c78-41bd-b9a9-ad990f33a9fb" />


#### After
<img width="1728" height="1079" alt="image" src="https://github.com/user-attachments/assets/54fc0094-52b6-4a65-9bb0-ca67fd6c388c" />
