### PR TITLE
Use `vim-better-whitespace` for handling whitespaces

### DIFF
--- a/lua/plugins/plugins.lua
+++ b/lua/plugins/plugins.lua
@@ -1,6 +1,5 @@
 return {
   "airblade/vim-gitgutter",
-  "bronson/vim-trailing-whitespace",
   "github/copilot.vim",
   "pangloss/vim-javascript",
   "tpope/vim-endwise",

--- a/lua/plugins/whitespaces.lua
+++ b/lua/plugins/whitespaces.lua
@@ -1,0 +1,4 @@
+return {
+  "ntpeters/vim-better-whitespace",
+  event = "BufRead", -- See https://github.com/ntpeters/vim-better-whitespace/issues/172#issuecomment-3099581990
+}


### PR DESCRIPTION
## Motivation

`vim-trailing-whitespace` seems to be no longer maintained and the repo itself recommends `vim-better-whitespace` as a more complete alternative.

## Details

I had to add the configure it to activate only on the `BufRead` event as it was causing my snacks dashboard to have a lot whitespaces highlighted – see https://github.com/ntpeters/vim-better-whitespace/issues/172#issuecomment-3099581990.