### PR TITLE
Automatically install `ruby-lsp` gem if missing

### DIFF
--- a/lua/plugins/lsp-config.lua
+++ b/lua/plugins/lsp-config.lua
@@ -18,16 +18,26 @@ return {
     lazy = false,
     config = function()
       local lspconfig = require("lspconfig")
+      local utils = require("utils")
 
-      lspconfig.ruby_lsp.setup({
-        init_options = {
-          addonSettings = {
-            ["Ruby LSP Rails"] = {
-              enablePendingMigrationsPrompt = false,
+      local function setup_ruby_lsp()
+        lspconfig.ruby_lsp.setup({
+          init_options = {
+            addonSettings = {
+              ["Ruby LSP Rails"] = {
+                enablePendingMigrationsPrompt = false,
+              },
             },
           },
-        },
-      })
+        })
+      end
+
+      if utils.executable("ruby-lsp") then
+        setup_ruby_lsp()
+      else
+        utils.install_ruby_lsp(function() setup_ruby_lsp() end)
+      end
+
       lspconfig.ts_ls.setup({})
     end,
   },

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -5,4 +5,21 @@ function M.directory_has_files(dir)
   return handle and vim.loop.fs_scandir_next(handle) ~= nil
 end
 
+function M.install_ruby_lsp(on_success)
+  vim.fn.jobstart({ "gem", "install", "ruby-lsp" }, {
+    on_exit = function(_, code)
+      if code == 0 then
+        vim.notify("ruby-lsp installed successfully!", vim.log.levels.INFO)
+        on_success()
+      else
+        vim.notify("Failed to install ruby-lsp", vim.log.levels.ERROR)
+      end
+    end,
+  })
+end
+
+function M.executable(cmd)
+  return vim.fn.executable(cmd) == 1
+end
+
 return M

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -7,19 +7,16 @@ end
 
 function M.install_ruby_lsp(on_success)
   if not M.executable("ruby") then
-    vim.notify("Ruby is not installed, skipping ruby-lsp installation", vim.log.levels.WARN)
     return
   end
 
   local ruby_version = vim.fn.systemlist("ruby -v")[1]
   if not ruby_version or #ruby_version == 0 then
-    vim.notify("Unable to determine Ruby version", vim.log.levels.ERROR)
     return
   end
 
   local major, minor = ruby_version:match("ruby (%d+)%.(%d+)")
   if not (tonumber(major) > 3 or (tonumber(major) == 3 and tonumber(minor) >= 0)) then
-    vim.notify("Ruby version must be >= 3.0 to install ruby-lsp", vim.log.levels.WARN)
     return
   end
 

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -6,6 +6,23 @@ function M.directory_has_files(dir)
 end
 
 function M.install_ruby_lsp(on_success)
+  if not M.executable("ruby") then
+    vim.notify("Ruby is not installed, skipping ruby-lsp installation", vim.log.levels.WARN)
+    return
+  end
+
+  local ruby_version = vim.fn.systemlist("ruby -v")[1]
+  if not ruby_version or #ruby_version == 0 then
+    vim.notify("Unable to determine Ruby version", vim.log.levels.ERROR)
+    return
+  end
+
+  local major, minor = ruby_version:match("ruby (%d+)%.(%d+)")
+  if not (tonumber(major) > 3 or (tonumber(major) == 3 and tonumber(minor) >= 0)) then
+    vim.notify("Ruby version must be >= 3.0 to install ruby-lsp", vim.log.levels.WARN)
+    return
+  end
+
   vim.fn.jobstart({ "gem", "install", "ruby-lsp" }, {
     on_exit = function(_, code)
       if code == 0 then


### PR DESCRIPTION
This pull request introduces enhancements to the LSP (Language Server Protocol) configuration, specifically for Ruby, by automating the installation and setup of `ruby-lsp` if it is not already present.