### PR TITLE
Add FING GitLab URL as an example for `vim-rhubarb`

### DIFF
--- a/lua/config/vim-options.lua
+++ b/lua/config/vim-options.lua
@@ -17,3 +17,8 @@ if vim.fn.has("nvim-0.11") == 1 then
 end
 
 vim.wo.number = true
+
+-- Here we set the custom GitHub Enterprise root URLs for vim-rhubarb
+vim.g.github_enterprise_urls = {
+  "gitlab.fing.edu.uy",
+}


### PR DESCRIPTION
#### Summary

This PR updates the configuration to include a GitHub Enterprise URL example for `vim-rhubarb`.